### PR TITLE
Use Config File instead of Arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ At this present moment that is only `Cloud Flare`
 
 These certificates can have up to `50` sub-domains and no `Wild Card`
 
-You can generate `Lets Encrypt Certificates` with the `SAN Extension` using the `HTTP-01` challenge, 
+You can generate `Lets Encrypt Certificates` with the `SAN Extension` using the `HTTP-01` challenge 
 
 This is the default configuration.
 

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 # server-ssl.js
 
-Configurable `SSL Server` that runs on [`Node.js`](https://nodejs.org/en) which can be used for development or production
-
-Create and renew `Lets Encrypt Certificates` automatically using `ACME` using `DNS-01` with supported providers or `HTTP-01`
+[`Node.js`](https://nodejs.org/en) server that is `SSL` by default that can be used for development or production
 
 Designed to get out of your way so you can still change _anything_
 
---------
+Creates and renews `Lets Encrypt Certificates` automatically using `ACME`
 
-### Getting Started
+If you use `CloudFlare` you can get `Wildcard Certificates`
+
+## Getting Started
 
 The easiest usage would be to serve a website:
 
@@ -21,109 +21,82 @@ The easiest usage would be to serve a website:
 5. Run `node server-ssl.js`
 6. View your website at `https://localhost`
 
-[![](https://i.imgur.com/0IVqrfn.gif)](https://github.com/FirstTimeEZ/server-ssl/archive/refs/heads/main.zip)
+![](https://i.imgur.com/ZYXoLMy.gif)
+
+You can also use different kinds of `Lets Encrypt!` certificates, see configuration below.
+
+![](https://i.imgur.com/mQ4uaxL.gif)
+
 
 The default page/config is a simple [`API`](https://github.com/FirstTimeEZ/simple-api-router) that serves and displays the `time`
 
 [![](https://i.imgur.com/DEbJVUq.png)](https://github.com/FirstTimeEZ/server-ssl/archive/refs/heads/main.zip)
 
-### Advanced/Production Usage
+## Advanced/Production Usage
 
-`node server-ssl.js` takes your arguments and starts the server
+`server-ssl.js` has a configuration file called `server-ssl.sc` that contains all the options you can change
 
+#### Default Configuration `(server-ssl.sc)`
+ 
 ```
-# Start for production (Lets Encrypt!) with SAN Extension
-node server-ssl.js --letsEncrypt --domains=['www.ssl.boats','ssl.boats']
-```
+portHttps          :: 443                                // The port number for HTTPS
+portHttp           :: 80                                 // The port number for HTTP that will be redirected
 
-[![](https://i.imgur.com/BT8EEWj.gif)](https://github.com/FirstTimeEZ/server-ssl/archive/refs/heads/main.zip)
+certificate        :: "certificate.pem"                  // The path to the certificate file.
+private-key        :: "private-key.pem"                  // The path to the private key for the certificate.
 
-### Optional Arguments
+websiteRoot        :: "wwwroot"                          // The directory for the website files
+entryPage          :: "index.html"                       // The page to use for the websites entry point 
+errorRoot          :: "error"                            // The directory for error messages (404,500)
 
-`server-ssl.js` has some optional arguments you can use in production if the defaults aren't enough.
+noCheckNodeVersion :: false                              // True to skip checking Node.js version
 
-| Arguments/Flags       | Description                                      | Default Value         |
-|-------------------------|----------------------------------|-----------------------|
-| `--port=`      | The port number for `HTTPS` | `443` |
-| `--portHttp=`  | The port number for HTTP that will be redirected | `80` |
-| `--cert=`      | The path to the `SSL` certificate file. | `"certificate.pem"` |
-| `--pk=`        | The path to the private key file for the `SSL` certificate. | `"private-key.pem"` |
-| `--site=`      | The directory for the website files | `"wwwroot"` |
-| `--error=`     | The directory for error messages (404,500) | `"error"` |
-| `--entry=`     | The page to use for the entry point | `"index.html"` |
+useLetsEncrypt     :: false                              // Use Lets Encrypt! to generate a certificate
+domains            :: ["ssl.boats","www.ssl.boats"]      // Domains to generate the certificate for
+generateCertAnyway :: false                              // True to generate before the recommended time
+useStaging         :: false                              // True to use the staging server to avoid rate limits
 
-All Arguments are case sensitive.
-
-### Use Lets Encrypt!
-
-You can use `Lets Encrypt` to generate certificates.
-
-Certificates are valid for `90 days` but are renewed automatically sooner.
-
-The certificates will be changed automatically when they are updated, you don't need to do anything.
-
-| Automated Lets Encrypt!       | Description                                      |
-|-------------------------|----------------------------------|
-| `--letsEncrypt` | `Lets Encrypt!` should be used to generate 90 day certificates automatically |
-| `--domains=` | Domains to generate certificates for, this can not include wild cards, this should be an array. eg. `--domains=['www.ssl.boats','ssl.boats']` |
-| `--generateAnyway` | Certificates should always be generated when the server starts, this could get you rate limited, maybe use `--staging`  |
-| `--staging` | The `Lets Encrypt!` staging server should be used instead of production |
-
-```
-node server-ssl.js --letsEncrypt --domains=['www.ssl.boats','ssl.boats']
+useDnsProvider     :: false                              // Use the DNS-01 Challenge to generate certificate
+providerName       :: "Cloud Flare"                      // Name of supported DNS Provider
+providerToken      :: "apiTokenWithDnsEditPermission"    // API Token for DNS Provider
+providerZone       :: ""                                 // ZoneId for DNS Provider, may found automatically.
 ```
 
-### Wild Card Certificates
+#### Multiple Configuration Files
+
+You can create multiple configuration files and choose which one to load as an argument.
+
+```
+node server-ssl --config="server-ssl-staging.sc"
+```
+
+If no argument is provided the default configuration file is loaded. `(server-ssl.sc)`
+
+#### Generate Wild Card Certificates
 
 You can generate `Wild Card Certificates` if you use a supported `DNS-01` provider
 
 At this present moment that is only `Cloud Flare`
 
-```
-let dnsProvider = {
-    name: "Cloud Flare",
-    token: "apiTokenWithDnsEditPermission",
-    zone: "zoneId" // optional if it cant be found automatically.
-}
-```
+![](https://i.imgur.com/R132a6z.gif)
 
-Then to generate the certificate add a wildcard to the apex, eg. `*.ssl.boats`
+#### Generate SAN Certificates
 
-```
---domains=['*.ssl.boats'] --staging
-```
+These certificates can have up to `50` sub-domains and no `Wild Card`
 
-[![](https://i.imgur.com/XA82Kt7.gif)](https://github.com/FirstTimeEZ/server-ssl/archive/refs/heads/main.zip)
+You can generate `Lets Encrypt Certificates` with the `SAN Extension` using the `HTTP-01` challenge, 
 
---------
+This is the default configuration.
 
-### Always Redirect HTTP to HTTPS
+![](https://i.imgur.com/VkOrZcX.gif)
+
+#### Always Redirects `HTTP` to `HTTPS`
 
 `HTTP` requests from end users are always redirected to `HTTPS`
 
 `ACME Challenges` transparently happen over `HTTP` to create/issue a new certificate
 
---------
-
-### Anything [Node.js](https://nodejs.org/docs/latest/api/) can do..
-
-At the end of the day, this is just a [`Node.js`](https://nodejs.org/docs/latest/api/) server that sets up `SSL` automatically
-
-```
-const HTTPS_SERVER = createServerHTTPS(STATE.loadDefaultSecureContext(), (req, res) => {
-    // do whatever you like
-})...
-```
-
-You can remove everything inside `HTTPS_SERVER` and do whatever you like.
-
-There are also helpers you can use in `STATE`
-
---------
-
-### Default Layout
-
-This layout keeps the project organized and maintainable, separating error handling, website content, and server configuration.
+## Default Layout
 
 ```
 /root
@@ -150,12 +123,11 @@ This layout keeps the project organized and maintainable, separating error handl
 ├── /wwwroot
 │   └── index.html <---- Your website goes here
 │
+├── server-ssl.sc
 └── server-ssl.js
 ```
 
---------
-
-### 404/500 Pages
+## 404/500 Pages
 
 The server is configured to serve custom `404` and `500` error pages, instead of plain-text.
 
@@ -166,18 +138,3 @@ Currently everything is treated like a `Server Error` except for `Not Found`
 [![](https://i.imgur.com/l8DMrQY.png)](https://github.com/FirstTimeEZ/server-ssl/archive/refs/heads/main.zip) [![](https://i.imgur.com/mP2d4vi.png)](https://github.com/FirstTimeEZ/server-ssl/archive/refs/heads/main.zip)
 
 These pages will automatically select light/dark mode
-
---------
-
-### Bring Your Own SSL Certificate
-
-Convert your `certificate` and `private key` to `PEM` format and place them in the `ssl` folder
-
-```
-├── /ssl
-│   ├── /production <> staging
-│   │   │
-│   │   ├── ...
-│   │   ├── private-key.pem <--- Your private key goes here
-│   │   └── certificate.pem <--- Your certificate goes here
-```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "server-ssl",
-  "version": "43.0.2",
+  "version": "44.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "server-ssl",
-      "version": "43.0.2",
+      "version": "44.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "base-acme-client": "^30.0.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "server-ssl",
   "author": "FirstTimeEZ",
-  "version": "43.0.2",
+  "version": "44.0.1",
   "description": "Configurable SSL Server that runs on Node.js which can be used for development or production and can create and renew Lets Encrypt Certificates automatically using ACME",
   "main": "template; do not import; read the Getting Started of the README, maybe you want to use: lets-encrypt-acme-client",
   "type": "module",

--- a/server-ssl.js
+++ b/server-ssl.js
@@ -41,13 +41,6 @@ const HTTPS_SERVER = createServerHTTPS(STATE.loadDefaultSecureContext(), (req, r
 
 STATE.startHttpChallengeListener();  // Lets Encrypt! HTTP-01 ACME Challenge Mixin - Always Redirects HTTP to HTTPS unless doing a ACME Challenge
 
-let dnsProvider = null;
-
-// dnsProvider = {
-//     name: "Cloud Flare",
-//     token: "apiTokenWithDnsEditPermission"
-// }
-
-STATE.loadLetsEncryptAcmeDaemon(() => { STATE.loadNewSecureContext(HTTPS_SERVER); }, dnsProvider);
+STATE.loadLetsEncryptAcmeDaemon(() => { STATE.loadNewSecureContext(HTTPS_SERVER); });
 //                              ^^ Update Certificates Callback
 STATE.checkNodeForUpdates(); // Check Node.js version

--- a/server-ssl.sc
+++ b/server-ssl.sc
@@ -1,0 +1,21 @@
+portHttps          :: 443
+portHttp           :: 80
+
+certificate        :: "certificate.pem"
+private-key        :: "private-key.pem"
+
+websiteRoot        :: "wwwroot"
+entryPage          :: "index.html"
+errorRoot          :: "error"
+
+noCheckNodeVersion :: false
+
+useLetsEncrypt     :: false
+domains            :: ["ssl.boats","www.ssl.boats"]
+generateCertAnyway :: false
+useStaging         :: false
+
+useDnsProvider     :: false
+providerName       :: "Cloud Flare"
+providerToken      :: "apiTokenWithDnsEditPermission"
+providerZone       :: ""

--- a/ssl/state.js
+++ b/ssl/state.js
@@ -34,7 +34,6 @@ export const STATE = {
     __certPath: null,
     urlsArray: null,
     packageJson: null,
-    configFile: null,
     // Args
     optPk: null,
     optCert: null,
@@ -78,19 +77,21 @@ export const STATE = {
     NODE_URL_SPLITS: 7,
     // Methods
     importRequiredArguments: (__rootDir) => {
+        let configFile = null;
+
         process.argv.slice(2).forEach((arg) => {
-            arg.includes("--config=") && (STATE.configFile = arg.split("=")[1]);
+            arg.includes("--config=") && (configFile = arg.split("=")[1]);
             arg.includes("--staging") && (STATE.optStaging = true);
         });
 
-        if (STATE.configFile === null || STATE.configFile === "") {
-            STATE.configFile = "server-ssl.sc";
+        if (configFile === null || configFile === "") {
+            configFile = "server-ssl.sc";
         }
 
         let configBuffer = null;
 
-        if (existsSync(STATE.configFile)) {
-            configBuffer = readFileSync(STATE.configFile)
+        if (existsSync(configFile)) {
+            configBuffer = readFileSync(configFile)
         }
         else {
             console.log("Provide a valid configuration file or use the default one (server-ssl.sc)");

--- a/ssl/state.js
+++ b/ssl/state.js
@@ -95,112 +95,108 @@ export const STATE = {
             STATE.configFile = "server-ssl.sc";
         }
 
-        let config = null;
+        let configBuffer = null;
 
         if (existsSync(STATE.configFile)) {
-            config = readFileSync(STATE.configFile)
+            configBuffer = readFileSync(STATE.configFile)
         }
         else {
             console.log("Provide a valid configuration file or use the default one (server-ssl.sc)");
             process.exit(0);
         }
 
-        const map = new Map();
+        const configMap = new Map();
 
-        if (config !== null) {
-            const configText = config.toString('utf-8');
+        if (configBuffer !== null) {
+            const fullConfigText = configBuffer.toString('utf-8');
+            const splitOnLines = fullConfigText.split("\r\n");
 
-            const split = configText.split("\r\n");
+            for (let index = 0; index < splitOnLines.length; index++) {
+                const splitLine = splitOnLines[index];
+                const splitValue = splitLine.split(" ::");
 
-            for (let index = 0; index < split.length; index++) {
-                const splitAgain = split[index];
-
-                const split2 = splitAgain.split(" ::");
-
-                for (let index = 0; index < split2.length; index++) {
-                    split2[index] = split2[index].trim();
+                for (let index = 0; index < splitValue.length; index++) {
+                    splitValue[index] = splitValue[index].trim();
                 }
 
-                for (let index = 0; index < split2.length; index++) {
-                    const element = split2[index];
-                    index++;
-                    const element2 = split2[index];
+                for (let index = 0; index < splitValue.length; index++) {
+                    const key = splitValue[index++];
+                    const value = splitValue[index];
 
-                    if (element2 == undefined || element == undefined || element == '') {
+                    if (value == undefined || key == undefined || key == '') {
                         continue;
                     }
 
-                    map.set(element, element2);
+                    configMap.set(key, value);
                 }
             }
 
-            map.forEach((value, key) => {
+            configMap.forEach((value, key) => {
                 if (value === 'false') {
-                    map.set(key, false);
+                    configMap.set(key, false);
                 } else if (value === 'true') {
-                    map.set(key, true);
+                    configMap.set(key, true);
                 }
                 else if (value === '""') {
-                    map.set(key, undefined);
+                    configMap.set(key, undefined);
                 }
                 else if (value.startsWith('"')) {
-                    map.set(key, value.replaceAll('"', ''));
+                    configMap.set(key, value.replaceAll('"', ''));
                 }
                 else if (!isNaN(value)) {
-                    map.set(key, Number(value));
+                    configMap.set(key, Number(value));
                 }
 
             });
         }
 
-
-        const useStaging = map.get("useStaging");
+        const useStaging = configMap.get("useStaging");
         useStaging != undefined && !STATE.optStaging && (STATE.optStaging = useStaging);
-        
-        const portHttps = map.get("portHttps");
+
+        const portHttps = configMap.get("portHttps");
         portHttps != undefined && (STATE.optPort = portHttps);
-        
-        const portHttp = map.get("portHttp");
+
+        const portHttp = configMap.get("portHttp");
         portHttp != undefined && (STATE.optPortHttp = portHttp);
-        
-        const certificate = map.get("certificate");
+
+        const certificate = configMap.get("certificate");
         certificate != undefined && (STATE.optCert = certificate);
-        
-        const privateKey = map.get("private-key");
+
+        const privateKey = configMap.get("private-key");
         privateKey != undefined && (STATE.optPk = privateKey);
-        
-        const websiteRoot = map.get("websiteRoot");
+
+        const websiteRoot = configMap.get("websiteRoot");
         websiteRoot != undefined && (STATE.optWebsite = websiteRoot);
-        
-        const entryPage = map.get("entryPage");
+
+        const entryPage = configMap.get("entryPage");
         entryPage != undefined && (STATE.optEntry = entryPage);
-        
-        const errorRoot = map.get("errorRoot");
+
+        const errorRoot = configMap.get("errorRoot");
         errorRoot != undefined && (STATE.optError = errorRoot);
-        
-        const noCheckNodeVersion = map.get("noCheckNodeVersion");
+
+        const noCheckNodeVersion = configMap.get("noCheckNodeVersion");
         noCheckNodeVersion != undefined && (STATE.optNoVersionCheck = noCheckNodeVersion);
-        
-        const useLetsEncrypt = map.get("useLetsEncrypt");
+
+        const useLetsEncrypt = configMap.get("useLetsEncrypt");
         useLetsEncrypt != undefined && (STATE.optLetsEncrypt = useLetsEncrypt);
-        
-        const domains = map.get("domains");
+
+        const domains = configMap.get("domains");
         domains != undefined && (STATE.optDomains = domains);
-        
-        const generateCertAnyway = map.get("generateCertAnyway");
+
+        const generateCertAnyway = configMap.get("generateCertAnyway");
         generateCertAnyway != undefined && (STATE.optGenerateAnyway = generateCertAnyway);
-        
-        const useDnsProvider = map.get("useDnsProvider");
+
+        const useDnsProvider = configMap.get("useDnsProvider");
         useDnsProvider != undefined && (STATE.optUseDnsProvider = useDnsProvider);
-        
-        const providerName = map.get("providerName");
+
+        const providerName = configMap.get("providerName");
         providerName != undefined && (STATE.optProviderName = providerName);
-        
-        const providerToken = map.get("providerToken");
+
+        const providerToken = configMap.get("providerToken");
         providerToken != undefined && (STATE.optProviderToken = providerToken);
-        
-        const providerZone = map.get("providerZone");
-        providerZone != undefined && (STATE.optProviderZone = providerZone);        
+
+        const providerZone = configMap.get("providerZone");
+        providerZone != undefined && (STATE.optProviderZone = providerZone);
 
         if (STATE.optLetsEncrypt === true) {
             STATE.optDomains === null && (console.log("You must specify at least one domain to use --letsEncrypt"), STATE.optLetsEncrypt = null);

--- a/ssl/state.js
+++ b/ssl/state.js
@@ -32,10 +32,8 @@ export const STATE = {
     __sslFolder: null,
     __pkPath: null,
     __certPath: null,
-    override: null,
     urlsArray: null,
     packageJson: null,
-    expireDate: null,
     configFile: null,
     // Args
     optPk: null,
@@ -61,8 +59,6 @@ export const STATE = {
     // Consts
     SUCCESS: 200,
     REDIRECT: 301,
-    TWELVE_HOURS_MILLISECONDS: 43200000,
-    ONE_DAY_MILLISECONDS: 86400000,
     PAGE_NOT_FOUND: 'ENOENT',
     ADDR_IN_USE: 'EADDRINUSE',
     ERROR_NOT_FOUND: '404 - File Not Found',
@@ -78,10 +74,6 @@ export const STATE = {
     REDIRECT_LOCATION: 'Location',
     IN_USE: " in use, please close whatever is using the port and restart",
     NODE_URL: "https://nodejs.org/dist/latest/win-x64",
-    NODE_YES: "Node.js is up to date",
-    NODE_NO: "There is a more recent version of Node.js",
-    NODE_FIRST: "First time running Node.js",
-    NODE_FN: "last_update.ez",
     NODE_VERSION: "v",
     NODE_URL_SPLITS: 7,
     // Methods

--- a/ssl/state.js
+++ b/ssl/state.js
@@ -154,8 +154,8 @@ export const STATE = {
         }
 
 
-        const stage = map.get("useStaging");
-        stage != undefined && (STATE.optStaging = stage);
+        const useStaging = map.get("useStaging");
+        useStaging != undefined && !STATE.optStaging && (STATE.optStaging = useStaging);
         
         const portHttps = map.get("portHttps");
         portHttps != undefined && (STATE.optPort = portHttps);

--- a/ssl/state.js
+++ b/ssl/state.js
@@ -153,31 +153,54 @@ export const STATE = {
             });
         }
 
-        map.get("useStaging") != undefined && (STATE.optStaging = map.get("useStaging"));
 
-        map.get("portHttps") != undefined && (STATE.optPort = map.get("portHttps"));
-        map.get("portHttp") != undefined && (STATE.optPortHttp = map.get("portHttp"));
-
-        map.get("certificate") != undefined && (STATE.optCert = map.get("certificate"));
-        map.get("private-key") != undefined && (STATE.optPk = map.get("private-key"));
-
-        map.get("websiteRoot") != undefined && (STATE.optWebsite = map.get("websiteRoot"));
-        map.get("entryPage") != undefined && (STATE.optEntry = map.get("entryPage"));
-
-        map.get("errorRoot") != undefined && (STATE.optError = map.get("errorRoot"));
-
-        map.get("noCheckNodeVersion") != undefined && (STATE.optNoVersionCheck = map.get("noCheckNodeVersion"));
-
-        map.get("useLetsEncrypt") != undefined && (STATE.optLetsEncrypt = map.get("useLetsEncrypt"));
-
-        map.get("domains") != undefined && (STATE.optDomains = map.get("domains"));
-
-        map.get("generateCertAnyway") != undefined && (STATE.optGenerateAnyway = map.get("generateCertAnyway"));
-
-        map.get("useDnsProvider") != undefined && (STATE.optUseDnsProvider = map.get("useDnsProvider"));
-        map.get("providerName") != undefined && (STATE.optProviderName = map.get("providerName"));
-        map.get("providerToken") != undefined && (STATE.optProviderToken = map.get("providerToken"));
-        map.get("providerZone") != undefined && (STATE.optProviderZone = map.get("providerZone"));
+        const stage = map.get("useStaging");
+        stage != undefined && (STATE.optStaging = stage);
+        
+        const portHttps = map.get("portHttps");
+        portHttps != undefined && (STATE.optPort = portHttps);
+        
+        const portHttp = map.get("portHttp");
+        portHttp != undefined && (STATE.optPortHttp = portHttp);
+        
+        const certificate = map.get("certificate");
+        certificate != undefined && (STATE.optCert = certificate);
+        
+        const privateKey = map.get("private-key");
+        privateKey != undefined && (STATE.optPk = privateKey);
+        
+        const websiteRoot = map.get("websiteRoot");
+        websiteRoot != undefined && (STATE.optWebsite = websiteRoot);
+        
+        const entryPage = map.get("entryPage");
+        entryPage != undefined && (STATE.optEntry = entryPage);
+        
+        const errorRoot = map.get("errorRoot");
+        errorRoot != undefined && (STATE.optError = errorRoot);
+        
+        const noCheckNodeVersion = map.get("noCheckNodeVersion");
+        noCheckNodeVersion != undefined && (STATE.optNoVersionCheck = noCheckNodeVersion);
+        
+        const useLetsEncrypt = map.get("useLetsEncrypt");
+        useLetsEncrypt != undefined && (STATE.optLetsEncrypt = useLetsEncrypt);
+        
+        const domains = map.get("domains");
+        domains != undefined && (STATE.optDomains = domains);
+        
+        const generateCertAnyway = map.get("generateCertAnyway");
+        generateCertAnyway != undefined && (STATE.optGenerateAnyway = generateCertAnyway);
+        
+        const useDnsProvider = map.get("useDnsProvider");
+        useDnsProvider != undefined && (STATE.optUseDnsProvider = useDnsProvider);
+        
+        const providerName = map.get("providerName");
+        providerName != undefined && (STATE.optProviderName = providerName);
+        
+        const providerToken = map.get("providerToken");
+        providerToken != undefined && (STATE.optProviderToken = providerToken);
+        
+        const providerZone = map.get("providerZone");
+        providerZone != undefined && (STATE.optProviderZone = providerZone);        
 
         if (STATE.optLetsEncrypt === true) {
             STATE.optDomains === null && (console.log("You must specify at least one domain to use --letsEncrypt"), STATE.optLetsEncrypt = null);


### PR DESCRIPTION
- [x] use configuration file instead of arguments
- [x] keep `--staging` arg as override

```
portHttps          :: 443
portHttp           :: 80

certificate        :: "certificate.pem"
private-key        :: "private-key.pem"

websiteRoot        :: "wwwroot"
entryPage          :: "index.html"
errorRoot          :: "error"

noCheckNodeVersion :: false

useLetsEncrypt     :: false
domains            :: ["ssl.boats","www.ssl.boats"]
generateCertAnyway :: false
useStaging         :: false

useDnsProvider     :: false
providerName       :: "Cloud Flare"
providerToken      :: "apiTokenWithDnsEditPermission"
providerZone       :: ""
```

closes https://github.com/FirstTimeEZ/server-ssl/issues/17